### PR TITLE
Add JSONinja settings panel

### DIFF
--- a/src/main/kotlin/com/livteam/jsoninja/settings/JsoninjaSettingsConfigurable.kt
+++ b/src/main/kotlin/com/livteam/jsoninja/settings/JsoninjaSettingsConfigurable.kt
@@ -1,0 +1,61 @@
+package com.livteam.jsoninja.settings
+
+import com.intellij.openapi.options.SearchableConfigurable
+import com.intellij.openapi.components.service
+import com.intellij.ui.dsl.builder.panel
+import com.intellij.openapi.ui.DialogPanel
+import com.livteam.jsoninja.LocalizationBundle
+import javax.swing.JComponent
+import javax.swing.JCheckBox
+import javax.swing.JSpinner
+import javax.swing.SpinnerNumberModel
+
+class JsoninjaSettingsConfigurable : SearchableConfigurable {
+    private val settings = service<JsoninjaSettingsService>()
+
+    private lateinit var panel: DialogPanel
+    private lateinit var indentField: JSpinner
+    private lateinit var sortKeysCheck: JCheckBox
+    private lateinit var compactArraysCheck: JCheckBox
+
+    override fun getId(): String = "com.livteam.jsoninja.settings"
+
+    override fun getDisplayName(): String = LocalizationBundle.message("settings.display.name")
+
+    override fun createComponent(): JComponent {
+        panel = panel {
+            row(LocalizationBundle.message("settings.indent.size")) {
+                indentField = spinner(SpinnerNumberModel(settings.indentSize, 0, 8, 1)).component
+            }
+            row {
+                sortKeysCheck = checkBox(LocalizationBundle.message("settings.sort.keys"))
+                    .component
+                sortKeysCheck.isSelected = settings.sortKeys
+            }
+            row {
+                compactArraysCheck = checkBox(LocalizationBundle.message("settings.compact.arrays"))
+                    .component
+                compactArraysCheck.isSelected = settings.compactArrays
+            }
+        }
+        return panel
+    }
+
+    override fun isModified(): Boolean {
+        return indentField.value as Int != settings.indentSize ||
+                sortKeysCheck.isSelected != settings.sortKeys ||
+                compactArraysCheck.isSelected != settings.compactArrays
+    }
+
+    override fun apply() {
+        settings.indentSize = indentField.value as Int
+        settings.sortKeys = sortKeysCheck.isSelected
+        settings.compactArrays = compactArraysCheck.isSelected
+    }
+
+    override fun reset() {
+        indentField.value = settings.indentSize
+        sortKeysCheck.isSelected = settings.sortKeys
+        compactArraysCheck.isSelected = settings.compactArrays
+    }
+}

--- a/src/main/kotlin/com/livteam/jsoninja/settings/JsoninjaSettingsService.kt
+++ b/src/main/kotlin/com/livteam/jsoninja/settings/JsoninjaSettingsService.kt
@@ -1,0 +1,36 @@
+package com.livteam.jsoninja.settings
+
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+
+@Service(Service.Level.APP)
+@State(name = "JsoninjaSettings", storages = [Storage("jsoninja_settings.xml")])
+class JsoninjaSettingsService : PersistentStateComponent<JsoninjaSettingsState> {
+    private var state = JsoninjaSettingsState()
+
+    override fun getState(): JsoninjaSettingsState = state
+
+    override fun loadState(state: JsoninjaSettingsState) {
+        this.state = state
+    }
+
+    var indentSize: Int
+        get() = state.indentSize
+        set(value) { state.indentSize = value }
+
+    var sortKeys: Boolean
+        get() = state.sortKeys
+        set(value) { state.sortKeys = value }
+
+    var compactArrays: Boolean
+        get() = state.compactArrays
+        set(value) { state.compactArrays = value }
+}
+
+data class JsoninjaSettingsState(
+    var indentSize: Int = 2,
+    var sortKeys: Boolean = false,
+    var compactArrays: Boolean = false
+)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -13,6 +13,7 @@
 
     <extensions defaultExtensionNs="com.intellij">
         <toolWindow factoryClass="com.livteam.jsoninja.ui.toolWindow.JsoninjaToolWindowFactory" id="JSONinja" icon="/META-INF/pluginIcon.svg"/>
+        <applicationConfigurable id="com.livteam.jsoninja.settings" displayName="JSONinja" instance="com.livteam.jsoninja.settings.JsoninjaSettingsConfigurable"/>
     </extensions>
 
     <applicationListeners>

--- a/src/main/resources/messages/LocalizationBundle.properties
+++ b/src/main/resources/messages/LocalizationBundle.properties
@@ -42,3 +42,9 @@ validation.error.positive.integer.required=Please enter a valid positive integer
 dialog.generate.json.label.max.depth=Max Generation Depth:
 dialog.generate.json.comment.max.depth=Nesting level limit (1 or greater)
 validation.error.positive.integer.required.ge1=Please enter a valid integer greater than or equal to 1.
+
+# Settings
+settings.display.name=JSONinja Settings
+settings.indent.size=Indent size
+settings.sort.keys=Sort object keys alphabetically
+settings.compact.arrays=Compact array output

--- a/src/main/resources/messages/LocalizationBundle_en.properties
+++ b/src/main/resources/messages/LocalizationBundle_en.properties
@@ -42,3 +42,9 @@ validation.error.positive.integer.required=Please enter a valid positive integer
 dialog.generate.json.label.max.depth=Max Generation Depth:
 dialog.generate.json.comment.max.depth=Nesting level limit (1 or greater)
 validation.error.positive.integer.required.ge1=Please enter a valid integer greater than or equal to 1.
+
+# Settings
+settings.display.name=JSONinja Settings
+settings.indent.size=Indent size
+settings.sort.keys=Sort object keys alphabetically
+settings.compact.arrays=Compact array output

--- a/src/main/resources/messages/LocalizationBundle_ko.properties
+++ b/src/main/resources/messages/LocalizationBundle_ko.properties
@@ -42,3 +42,9 @@ validation.error.positive.integer.required=\uC62C\uBC14\uB978 \uC591\uC758 \uC81
 dialog.generate.json.label.max.depth=\uCD5C\uB300 \uC0DD\uC131 \uAE4A\uC774 (Max Depth):
 dialog.generate.json.comment.max.depth=\uC911\uCCA9 \uB808\uBCA8 \uC81C\uD55C (1 \uC774\uC0C1)
 validation.error.positive.integer.required.ge1=1 \uC774\uC0C1\uC758 \uC62C\uBC14\uB978 \uC815\uC218\uB97C \uC785\uB825\uD558\uC138\uC694.
+
+# Settings
+settings.display.name=JSONinja \uC124\uC815
+settings.indent.size=\uB4E4\uC5EC\uC4F0\uAE30 \uACF5\uBC31 \uC218
+settings.sort.keys=\uAC1D\uCCB4 \uD0A4\uB97C \uC54C\uD30C\uBCB3 \uC21C\uC73C\uB85C \uC815\uB82C
+settings.compact.arrays=\uBC30\uC5F4 \uCD95\uC18C \uCD9C\uB825


### PR DESCRIPTION
## Summary
- add an application-level settings service
- implement a configurable to expose indent and sort options
- register configurable in plugin.xml
- provide localised labels for settings panel

## Testing
- `./gradlew test` *(fails: No route to host)*