### PR TITLE
fix: JSON 파싱 오류 수정 및 코드 품질 개선

### DIFF
--- a/src/test/kotlin/com/livteam/jsoninja/services/JsonFormatterServiceTest.kt
+++ b/src/test/kotlin/com/livteam/jsoninja/services/JsonFormatterServiceTest.kt
@@ -132,4 +132,22 @@ class JsonFormatterServiceTest : BasePlatformTestCase() {
         assertFalse(sortedFormattedJson == unsortedFormattedJson)
         // Reset settings to default
     }
+
+    fun testFormatInvalidJsonWithTrailingContent() {
+        // Test the bug case: partially valid JSON with trailing invalid content
+        val partiallyValidJson = """{"test":1},"test""""
+        val result = jsonFormatterService.formatJson(partiallyValidJson, JsonFormatState.PRETTIFY)
+
+        // The formatter should return the original string unchanged when JSON is invalid
+        assertEquals(partiallyValidJson, result)
+
+        // Verify that this JSON is indeed considered invalid
+        assertFalse(jsonFormatterService.isValidJson(partiallyValidJson))
+
+        // Additional test cases for similar scenarios
+        val anotherInvalidJson = """[1,2,3]extra"""
+        val anotherResult = jsonFormatterService.formatJson(anotherInvalidJson, JsonFormatState.PRETTIFY)
+        assertEquals(anotherInvalidJson, anotherResult)
+        assertFalse(jsonFormatterService.isValidJson(anotherInvalidJson))
+    }
 }


### PR DESCRIPTION
- JsonFormatterService의 isValidJson 메서드에서 readTree 호출 오류 수정
  - JsonParser를 사용하여 전체 JSON을 파싱하고 trailing token 검증
- unescapeBeautifiedJson 메서드의 변수 선언 경고 수정 (var → val)
- 부분적으로 유효한 JSON에 대한 테스트 케이스 추가

🤖 Generated with [Claude Code](https://claude.ai/code)