### PR TITLE
feat(json 포멧 기능추가):

### DIFF
--- a/src/main/kotlin/com/livteam/jsoninja/services/JsonFormatterService.kt
+++ b/src/main/kotlin/com/livteam/jsoninja/services/JsonFormatterService.kt
@@ -3,6 +3,7 @@ package com.livteam.jsoninja.services
 import com.intellij.openapi.components.Service
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.core.util.DefaultIndenter
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter
 import com.fasterxml.jackson.databind.SerializationFeature
@@ -32,13 +33,15 @@ class JsonFormatterService(private val project: Project) {
             configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
             configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true)
             configure(DeserializationFeature.FAIL_ON_TRAILING_TOKENS, true)
+            // 파서 레벨 기능 - trailing comma 허용
+            configure(JsonParser.Feature.ALLOW_TRAILING_COMMA, true)
         }
 
         private val SORTED_MAPPER = DEFAULT_MAPPER.copy().apply {
             configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true)
         }
 
-        private val NON_SORTED_MAPPER = ObjectMapper().apply {
+        private val NON_SORTED_MAPPER = DEFAULT_MAPPER.copy().apply {
             configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, false)
         }
 

--- a/src/test/kotlin/com/livteam/jsoninja/services/JsonFormatterServiceTest.kt
+++ b/src/test/kotlin/com/livteam/jsoninja/services/JsonFormatterServiceTest.kt
@@ -150,4 +150,83 @@ class JsonFormatterServiceTest : BasePlatformTestCase() {
         assertEquals(anotherInvalidJson, anotherResult)
         assertFalse(jsonFormatterService.isValidJson(anotherInvalidJson))
     }
+
+    fun testFormatJsonWithTrailingCommaInObject() {
+        // Test formatting JSON with trailing comma in object
+        val inputWithTrailingComma = """[{"items": 72183,}]"""
+        
+        // Should be considered valid JSON
+        assertTrue(jsonFormatterService.isValidJson(inputWithTrailingComma))
+        
+        // Should format correctly (trailing comma removed)
+        val prettified = jsonFormatterService.formatJson(inputWithTrailingComma, JsonFormatState.PRETTIFY)
+        assertTrue(prettified.contains("\n"))
+        assertTrue(prettified.contains("  "))
+        assertFalse(prettified.contains(",}"))
+        assertTrue(prettified.contains("72183"))
+        
+        // Test uglify mode
+        val uglified = jsonFormatterService.formatJson(inputWithTrailingComma, JsonFormatState.UGLIFY)
+        assertEquals("""[{"items":72183}]""", uglified)
+    }
+
+    fun testFormatJsonWithTrailingCommaInObjectAndArray() {
+        // Test formatting JSON with trailing commas in both object and array
+        val inputWithTrailingCommas = """[{"items": 72183,},]"""
+        
+        // Should be considered valid JSON
+        assertTrue(jsonFormatterService.isValidJson(inputWithTrailingCommas))
+        
+        // Should format correctly (trailing commas removed)
+        val prettified = jsonFormatterService.formatJson(inputWithTrailingCommas, JsonFormatState.PRETTIFY)
+        assertTrue(prettified.contains("\n"))
+        assertTrue(prettified.contains("  "))
+        assertFalse(prettified.contains(",}"))
+        assertFalse(prettified.contains(",]"))
+        assertTrue(prettified.contains("72183"))
+        
+        // Test uglify mode
+        val uglified = jsonFormatterService.formatJson(inputWithTrailingCommas, JsonFormatState.UGLIFY)
+        assertEquals("""[{"items":72183}]""", uglified)
+    }
+
+    fun testFormatSimpleObjectWithTrailingComma() {
+        // Test simple object with trailing comma
+        val inputWithTrailingComma = """{"a":1,}"""
+        
+        // Should be considered valid JSON
+        assertTrue(jsonFormatterService.isValidJson(inputWithTrailingComma))
+        
+        // Should format correctly
+        val uglified = jsonFormatterService.formatJson(inputWithTrailingComma, JsonFormatState.UGLIFY)
+        assertEquals("""{"a":1}""", uglified)
+        
+        val prettified = jsonFormatterService.formatJson(inputWithTrailingComma, JsonFormatState.PRETTIFY)
+        assertTrue(prettified.contains("\n"))
+        assertFalse(prettified.contains(",}"))
+    }
+
+    fun testFormatArrayWithTrailingComma() {
+        // Test array with trailing comma
+        val inputWithTrailingComma = """[1,2,3,]"""
+        
+        // Should be considered valid JSON
+        assertTrue(jsonFormatterService.isValidJson(inputWithTrailingComma))
+        
+        // Should format correctly
+        val uglified = jsonFormatterService.formatJson(inputWithTrailingComma, JsonFormatState.UGLIFY)
+        assertEquals("[1,2,3]", uglified)
+    }
+
+    fun testInvalidJsonWithTrailingTokensStillFails() {
+        // Ensure FAIL_ON_TRAILING_TOKENS still works (not related to commas inside JSON)
+        val inputWithTrailingTokens = """{"a":1} junk"""
+        
+        // Should be considered invalid
+        assertFalse(jsonFormatterService.isValidJson(inputWithTrailingTokens))
+        
+        // Should return original when formatting fails
+        val result = jsonFormatterService.formatJson(inputWithTrailingTokens, JsonFormatState.PRETTIFY)
+        assertEquals(inputWithTrailingTokens, result)
+    }
 }


### PR DESCRIPTION
json format시 trailing comma(후행콤마) 있어도 포멧 되도록 변경